### PR TITLE
feat: allow to skip twitter verification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ const fn default_token_amount() -> u64 {
     20
 }
 
+const fn default_verify_following_webb() -> bool {
+    true
+}
+
 #[derive(Deserialize)]
 pub struct AppConfig {
     db: PathBuf,
@@ -74,6 +78,9 @@ pub struct AppConfig {
     pub time_to_wait_between_claims: std::time::Duration,
     #[serde(default = "default_token_amount")]
     pub token_amount: u64,
+    /// Whether to verify that the user is following the webb twitter account
+    #[serde(default = "default_verify_following_webb")]
+    pub verify_following_webb: bool,
 }
 
 fn auth_db_firing() -> impl Fairing {


### PR DESCRIPTION
This a small change that allows us to control the verification step of checking if the account is following webbprotocol account on twitter or not. Useful for testing 😉 

```toml
verify_following_webb = false # default to `true`
```