### PR TITLE
Add a way to request only native tokens instead of ERC20

### DIFF
--- a/Rocket.example.toml
+++ b/Rocket.example.toml
@@ -2,6 +2,7 @@
 db = "faucet"
 mnemonic="<mnemonic>"
 time_to_wait_between_claims = { secs = 0, nanos = 0 }
+native_token_amount = 0.5
 token_amount = 10
 
 [global.oauth.twitter]

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ const fn default_token_amount() -> u64 {
     20
 }
 
+const fn default_native_token_amount() -> f64 {
+    0.5
+}
+
 const fn default_verify_following_webb() -> bool {
     true
 }
@@ -79,6 +83,8 @@ pub struct AppConfig {
     pub time_to_wait_between_claims: std::time::Duration,
     #[serde(default = "default_token_amount")]
     pub token_amount: u64,
+    #[serde(default = "default_native_token_amount")]
+    pub native_token_amount: f64,
     /// Whether to verify that the user is following the webb twitter account
     #[serde(default = "default_verify_following_webb")]
     pub verify_following_webb: bool,

--- a/src/txes/types.rs
+++ b/src/txes/types.rs
@@ -48,6 +48,7 @@ pub enum Transaction {
         provider: EthersClient,
         to: Address,
         amount: U256,
+        native_token_amount: U256,
         token_address: Option<Address>,
         result_sender: oneshot::Sender<Result<TxResult, Error>>,
     },
@@ -55,6 +56,7 @@ pub enum Transaction {
         api: OnlineClient<PolkadotConfig>,
         to: AccountId32,
         amount: u128,
+        native_token_amount: u128,
         asset_id: Option<u32>,
         signer: sp_core::sr25519::Pair,
         result_sender: oneshot::Sender<Result<TxResult, Error>>,
@@ -68,6 +70,7 @@ impl std::fmt::Debug for Transaction {
                 provider,
                 to,
                 amount,
+                native_token_amount,
                 token_address,
                 result_sender,
             } => f
@@ -75,6 +78,7 @@ impl std::fmt::Debug for Transaction {
                 .field("provider", provider)
                 .field("to", to)
                 .field("amount", amount)
+                .field("native_token_amount", native_token_amount)
                 .field("token_address", token_address)
                 .field("result_sender", result_sender)
                 .finish(),
@@ -84,11 +88,13 @@ impl std::fmt::Debug for Transaction {
                 amount,
                 asset_id,
                 result_sender,
+                native_token_amount,
                 ..
             } => f
                 .debug_struct("Substrate")
                 .field("api", api)
                 .field("to", to)
+                .field("native_token_amount", native_token_amount)
                 .field("amount", amount)
                 .field("asset_id", asset_id)
                 .field("signer", &"<hidden>")


### PR DESCRIPTION
Adds an optional `onlyNativeTokens` boolean (default `false`) to the payload to request only native tokens instead of ERC20. 

From the Faucet UI, it should be as simple as a Toggle and if enabled the UI Should send two requests one without this value (to request the ERC20 tokens) and another one for the Native tokens, since we can't send two txs in one time to the blockchain, nonetheless.

Default value for the Native token amount is `0.5` However, this configurable from the config files.

Closes #19 